### PR TITLE
Use bucket system for on_tick updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 .DS_Store
+.vscode

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "LunarLandings",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "title": "Lunar Landings",
   "author": "Xorimuth",
   "homepage": "https://discord.gg/pkJc4v9nfT",

--- a/migrations/2024-05-09-buckets.lua
+++ b/migrations/2024-05-09-buckets.lua
@@ -1,0 +1,17 @@
+local Buckets = require "scripts.buckets"
+
+if not global.oxygen_diffusers.interval then
+  global.oxygen_diffusers = Buckets.migrate(global.oxygen_diffusers)
+end
+
+if not global.rocket_silos.interval then
+  global.rocket_silos = Buckets.migrate(global.rocket_silos)
+end
+
+if not global.rtgs.interval then
+  global.rtgs = Buckets.migrate(global.rtgs)
+end
+
+if not global.steam_condensers.interval then
+  global.steam_condensers = Buckets.migrate(global.steam_condensers)
+end

--- a/prototypes/oxygen-diffuser.lua
+++ b/prototypes/oxygen-diffuser.lua
@@ -193,7 +193,8 @@ data:extend{
     --damaged_trigger_effect = hit_effects.entity(),
     fluid_box =
     {
-      base_area = 1,
+      base_area = 2,
+      base_level = -1,
       pipe_covers = pipecoverspictures(),
       pipe_connections =
       {

--- a/scripts/buckets.lua
+++ b/scripts/buckets.lua
@@ -1,0 +1,78 @@
+local DEFAULT_INTERVAL = 60
+
+local Buckets = {}
+
+function Buckets.new(interval)
+  local bucket = { list = {}, interval = interval or DEFAULT_INTERVAL }
+  return bucket
+end
+
+function Buckets.add(bucket, id, data)
+  local bucket_id = id % bucket.interval
+  bucket.list[bucket_id] = bucket.list[bucket_id] or {}
+  bucket.list[bucket_id][id] = data or {}
+end
+
+function Buckets.get(bucket, id)
+  local bucket_id = id % bucket.interval
+  local bucket_data = bucket.list[bucket_id]
+  return bucket_data and bucket_data[id]
+end
+
+function Buckets.remove(bucket, id)
+  local bucket_id = id % bucket.interval
+  if bucket.list[bucket_id] then
+    bucket.list[bucket_id][id] = nil
+  end
+end
+
+function Buckets.get_bucket(bucket, id)
+  local bucket_id = id % bucket.interval
+  bucket.list[bucket_id] = bucket.list[bucket_id] or {}
+  return bucket.list[bucket_id]
+end
+
+function Buckets.update(bucket, callback, tick)
+  local bucket_id = (tick or game.tick) % bucket.interval
+  local bucket_data = bucket.list[bucket_id]
+  for _, data in pairs(bucket_data or {}) do
+    callback(data)
+  end
+end
+
+function Buckets.update_unit(bucket, callback, id)
+  local data = Buckets.get(bucket, id)
+  if data then
+    callback(data)
+  end
+end
+
+function Buckets.reallocate(bucket, new_interval)
+  local tmp = {}
+  if bucket.interval == new_interval then
+    return
+  end
+
+  for b_id=0, bucket.interval do
+    local bucket_data = bucket.list[b_id]
+    for id, data in pairs(d_data or {}) do
+      tmp[id] = data
+    end
+    bucket.list[b_id] = nil
+  end
+
+  bucket.interval = new_interval or DEFAULT_INTERVAL
+  for id, data in pairs(tmp) do
+    Buckets.add(bucket, id, data)
+  end
+end
+
+function Buckets.migrate(tbl, interval)
+  local bucket = Buckets.new(interval)
+  for id, data in pairs(tbl) do
+    Buckets.add(bucket, id, data)
+  end
+  return bucket
+end
+
+return Buckets

--- a/scripts/rtg.lua
+++ b/scripts/rtg.lua
@@ -1,3 +1,6 @@
+local Buckets = require "scripts.buckets"
+
+---@type ScriptLib
 local RTG = {}
 local ln_2 = 0.69314718
 
@@ -8,7 +11,7 @@ local half_life = 0.1 * initial_energy * ln_2 / initial_power  -- 600 kW
 local initial_health = 600
 
 local function on_tick(event)
-  for unit_number, rtg_data in pairs(global.rtgs) do
+  for unit_number, rtg_data in pairs(Buckets.get_bucket(global.rtgs, event.tick)) do
     local entity = rtg_data.entity
     if entity.valid then
       local current_multiplier = 1 / (2^((event.tick-rtg_data.tick_created)/(half_life * 60)))
@@ -17,7 +20,7 @@ local function on_tick(event)
       local health = initial_health * current_multiplier
       entity.health = health
     else
-      global.rtgs[unit_number] = nil
+      Buckets.remove(global.rtgs, unit_number)
     end
   end
 end
@@ -26,10 +29,10 @@ local function on_entity_built(event)
   local entity = event.created_entity or event.entity
   if not entity.valid or entity.name ~= "ll-rtg" then return end
 
-  global.rtgs[entity.unit_number] = {
+  Buckets.add(global.rtgs, entity.unit_number, {
     entity = entity,
     tick_created = event.tick
-  }
+  })
 end
 
 local function on_entity_mined(event)
@@ -44,7 +47,7 @@ local function on_entity_mined(event)
     end
   end
 
-  global.rtgs[entity.unit_number] = nil
+  Buckets.remove(global.rtgs, entity.unit_number)
 end
 
 RTG.events = {
@@ -58,7 +61,7 @@ RTG.events = {
 }
 
 RTG.on_init = function ()
-  global.rtgs = {}
+  global.rtgs = Buckets.new()
 end
 
 RTG.on_configuration_changed = function(changed_data)


### PR DESCRIPTION
I've moved some of the cached data in `global` to a bucket system (instead of a dictionary id --> data, it's now a nested dictionary (id % update_interval) --> [id --> data].

Since you have more modules that call `on_tick`, I've made a separated module `Buckets` that can be imported and used whenever you need it. Transitioning to it is very easy overall: instead of calling:
`global.rtgs[entity.unit_number]` it is instead `Buckets.get(global.rtgs, entity.unit_number)`

Default interval is 60 ticks (so entities are updated 1 per second instead of every tick), but can be customized per module.

Added some `reallocate` and `migrate` functions ad hoc for you if you feel to change the update interval of a module or to migrate other contents from previous table (this is also used in the migration file to migrate from .12 and earlier).

By all means, I did not run it through profilers and such, but at first glance, seems to help
![LL_perf](https://github.com/tburrows13/LunarLandings/assets/93430988/cc9c4001-6140-42bf-8f5b-efba99795e14)


(the oxygenators's fluid box had to be doubled and moved to -1 to allow the fluid box to gather the fluids for a full 1s cycle)