### PR TITLE
Tint chemical plant recipes

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -16,3 +16,12 @@ space_train_tech.icon_mipmaps = 1
 
 data_util.remove_prerequisite("tech-space-trains", "battery")
 data_util.remove_prerequisite("tech-space-trains", "steel-processing")
+
+local space_train_refurbish = data.raw.recipe["space-train-battery-pack-refurbish"]
+if space_train_refurbish then
+  space_train_refurbish.crafting_machine_tint = space_train_refurbish.crafting_machine_tint or {}
+  space_train_refurbish.crafting_machine_tint.primary    = { r = 174, g = 139, b = 12 }
+  space_train_refurbish.crafting_machine_tint.secondary  = { r = 174, g = 139, b = 12 }
+  space_train_refurbish.crafting_machine_tint.tertiary   = { r = 174, g = 139, b = 12 }
+  space_train_refurbish.crafting_machine_tint.quaternary = { r = 174, g = 139, b = 12 }
+end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "LunarLandings",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "title": "Lunar Landings",
   "author": "Xorimuth",
   "homepage": "https://discord.gg/pkJc4v9nfT",

--- a/prototypes/aluminium.lua
+++ b/prototypes/aluminium.lua
@@ -92,7 +92,7 @@ data:extend{
   },
   {
     type = "recipe",
-    name = "ll-red-mud-recovery",  -- TODO set fluid tint
+    name = "ll-red-mud-recovery",
     icons = {
       {
         icon = "__LunarLandings__/graphics/icons/red-mud.png",
@@ -119,7 +119,13 @@ data:extend{
       {type="item", name="iron-ore", amount_min=0, amount_max=20},
     },
     subgroup = "ll-raw-material-moon",
-    order = "h[red-mud]"
+    order = "h[red-mud]",
+    crafting_machine_tint = {
+      primary    = {r = 53, g = 0, b = 0},
+      secondary  = {r = 53, g = 0, b = 0},
+      tertiary   = {r = 53, g = 0, b = 0},
+      quaternary = {r = 53, g = 0, b = 0},
+    },
   },
   {
     type = "recipe",

--- a/prototypes/recipe-changes.lua
+++ b/prototypes/recipe-changes.lua
@@ -17,3 +17,12 @@ bzutil.add_ingredient("processing-unit", "ll-silicon", 5)
 bzutil.add_ingredient("production-science-pack", "ll-heat-shielding", 2)
 
 bzutil.replace_ingredient("power-armor-mk2", "processing-unit", "ll-quantum-processor")
+
+local nuclear_fuel = data.raw.recipe["nuclear-fuel"]
+if nuclear_fuel then
+  nuclear_fuel.crafting_machine_tint = nuclear_fuel.crafting_machine_tint or {}
+  nuclear_fuel.crafting_machine_tint.primary    = { r = 0, g = 200, b = 0 }
+  nuclear_fuel.crafting_machine_tint.secondary  = { r = 0, g = 200, b = 0 }
+  nuclear_fuel.crafting_machine_tint.tertiary   = { r = 0, g = 200, b = 0 }
+  nuclear_fuel.crafting_machine_tint.quaternary = { r = 0, g = 200, b = 0 }
+end


### PR DESCRIPTION
The astroflux cannot be tinted (it's an assembler recipe) unless you want to move it to centrifuges.

Honestly. balance wise, I wouldnt mind using more centrifuges and advanced-luna assemblers in space with higher power demands, as it would be a reasonable game progression (unlike nauvis's easy power demands)

![tints](https://github.com/tburrows13/LunarLandings/assets/93430988/3fc60adb-c10f-4113-b7ec-0897a09bae19)
