### PR TITLE
fix: Don't crash when mining a landing pad

### DIFF
--- a/scripts/landing-pad.lua
+++ b/scripts/landing-pad.lua
@@ -136,7 +136,7 @@ local function on_entity_destroyed(event)
   if not entity_data then return end
 
   LandingPad.name_removed(entity_data.name, event.unit_number, entity_data.surface_name)
-  global.landings_pads[event.unit_number] = nil
+  global.landing_pads[event.unit_number] = nil
 end
 
 LandingPad.events = {


### PR DESCRIPTION
This should be `landing_pads`, not `landings_pads` (like line 135)

```
The mod Lunar Landings (1.0.8) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event LunarLandings::on_entity_destroyed (ID 160)
__LunarLandings__/scripts/landing-pad.lua:139: attempt to index field 'landings_pads' (a nil value)
stack traceback:
	__LunarLandings__/scripts/landing-pad.lua:139: in function 'handler'
	__core__/lualib/event_handler.lua:47: in function <__core__/lualib/event_handler.lua:45>
```