### PR TITLE
Lower core extractor module slots to 3

### DIFF
--- a/prototypes/core-extractor.lua
+++ b/prototypes/core-extractor.lua
@@ -49,7 +49,7 @@ data:extend({
 		  emissions_per_minute = 0
 		},
     allowed_effects = {"consumption", "pollution"},
-    module_specification = {module_slots = 4},
+    module_specification = {module_slots = 3},
     mining_speed = 1,
     resource_categories = {"ll-core"},
     energy_usage = "3MW",


### PR DESCRIPTION
They only accept efficiency modules, and with 3 tier 1's you're already at -90 and it is capped at -80.