### PR TITLE
Migrate 1.1 tile transition defintions for lunar foundation.

### DIFF
--- a/prototypes/tiles.lua
+++ b/prototypes/tiles.lua
@@ -129,78 +129,72 @@ data:extend{
     check_collision_with_entities = true,
     variants =
     {
-      empty_transitions = true,
+      empty_transitions = false,
       main = {
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile1.png",
-        count = 12,
-        size = 1,
-        scale = 0.5
-      },},
-
-      inner_corner =
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-inner-corner.png",
-        count = 1,
-        scale = 0.5
+        {
+          picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile1.png",
+          count = 12,
+          size = 1,
+          scale = 0.5
+        },
       },
-      inner_corner_mask =
-      {
-        picture = "__base__/graphics/terrain/concrete/concrete-inner-corner-mask.png",
-        count = 16,
-        scale = 0.5
-      },
-
-      outer_corner =
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-outer-corner.png",
-        count = 1,
-        scale = 0.5
-      },
-      outer_corner_mask =
-      {
-        picture = "__base__/graphics/terrain/concrete/concrete-outer-corner-mask.png",
-        count = 8,
-        scale = 0.5
-      },
-
-      side =
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-side.png",
-        count = 16,
-        scale = 0.5
-      },
-      side_mask =
-      {
-        picture = "__base__/graphics/terrain/concrete/concrete-side-mask.png",
-        count = 16,
-        scale = 0.5
-      },
-
-      u_transition =
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-u.png",
-        count = 1,
-        scale = 0.5
-      },
-      u_transition_mask =
-      {
-        picture = "__base__/graphics/terrain/concrete/concrete-u-mask.png",
-        count = 8,
-        scale = 0.5
-      },
-
-      o_transition =
-      {
-        picture = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-o.png",
-        count = 1,
-        scale = 0.5
-      },
-      o_transition_mask =
-      {
-        picture = "__base__/graphics/terrain/concrete/concrete-o-mask.png",
-        count = 4,
-        scale = 0.5
+      transition = {
+        layout = {
+          mask = {
+            inner_corner = {
+              spritesheet = "__base__/graphics/terrain/concrete/concrete-inner-corner-mask.png",
+              count = 16,
+              scale = 0.5
+            },
+            outer_corner = {
+              spritesheet = "__base__/graphics/terrain/concrete/concrete-outer-corner-mask.png",
+              count = 8,
+              scale = 0.5
+            },
+            side = {
+              spritesheet = "__base__/graphics/terrain/concrete/concrete-side-mask.png",
+              count = 16,
+              scale = 0.5
+            },
+            u_transition = {
+              spritesheet = "__base__/graphics/terrain/concrete/concrete-u-mask.png",
+              count = 8,
+              scale = 0.5
+            },
+            o_transition = {
+              spritesheet = "__base__/graphics/terrain/concrete/concrete-o-mask.png",
+              count = 4,
+              scale = 0.5
+            },
+          },
+          overlay = {
+            inner_corner = {
+              spritesheet = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-inner-corner.png",
+              count = 1,
+              scale = 0.5
+            },
+            outer_corner = {
+              spritesheet = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-outer-corner.png",
+              count = 1,
+              scale = 0.5
+            },
+            side = {
+              spritesheet = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-side.png",
+              count = 16,
+              scale = 0.5
+            },
+            u_transition = {
+              spritesheet = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-u.png",
+              count = 1,
+              scale = 0.5
+            },
+            o_transition = {
+              spritesheet = "__space-exploration-graphics__/graphics/terrain/space-platform-plating/tile-o.png",
+              count = 1,
+              scale = 0.5
+            },
+          },
+        },
       },
     },
 


### PR DESCRIPTION
This pull request migrates 1.1-style tile transitions for lunar foundation.

Before:
![image](https://github.com/user-attachments/assets/bd4ce419-baae-4917-9e20-ad399d2f5e7a)

After:
![image](https://github.com/user-attachments/assets/30157021-4fc1-4bf8-beca-09fd0955aa4c)
