### PR TITLE
Fixed incorrect shadow placement for the heat furnace.

### DIFF
--- a/prototypes/heat-furnace.lua
+++ b/prototypes/heat-furnace.lua
@@ -130,7 +130,7 @@ data:extend{
             height = 85,
             frame_count = 1,
             draw_as_shadow = true,
-            shift = util.by_pixel(39.25, 11.25),
+            shift = util.by_pixel(39.25 * 1.5, 11.25 * 1.5),
             scale = 0.5 * 1.5
           }
         }


### PR DESCRIPTION
This shadow positioning has always bugged me:

![image](https://github.com/user-attachments/assets/2da2b75f-dbbf-4c91-8a79-2dcfe271432e)

I have adjusted the shadow shift to their proper values. Here is the result:

![image](https://github.com/user-attachments/assets/66c914e4-13ea-44f4-9067-a693ace878c9)
