### PR TITLE
Properly localise the "atmospheric oxygen" surface property.

### DIFF
--- a/locale/en/LunarLandings.cfg
+++ b/locale/en/LunarLandings.cfg
@@ -202,7 +202,7 @@ luna=Luna
 ll-atmospheric-oxygen=Atmospheric oxygen
 
 [surface-property-unit]
-ll-atmospheric-oxygen= %
+ll-atmospheric-oxygen=__1__ %
 
 [ll-flying-text-info]
 cannot-be-placed-on=__1__ cannot be placed on __2__.


### PR DESCRIPTION
It seems the "atmospheric oxygen" surface property does not display the value. This PR fixes the bug.

Before;

![image](https://github.com/user-attachments/assets/2d2bafa0-1f47-4c26-929a-debc2ec1ed1f)

After;

![image](https://github.com/user-attachments/assets/3447e5de-8b2a-4cc0-9402-567e3c1cbe28)
