### PR TITLE
Fixed duplicate locale key between luna automation localised name and descrption.

### DIFF
--- a/locale/en/LunarLandings.cfg
+++ b/locale/en/LunarLandings.cfg
@@ -171,7 +171,7 @@ ll-research-productivity=Lab research productivity
 ll-used-rocket-part-recycling=Rockets return their rocket parts back to their silo after launch, for recycling.\nRockets launched from Luna deposit their rocket parts into the destination landing pad.
 rocket-silo=Allows you to launch a rocket into space.
 ll-luna-exploration=[font=default-bold]You must launch a satellite from a rocket silo before this technology can be researched.[/font]\nRe-establishes contact with the robot on Luna, allowing you to start building a factory there.\nLuna robot can be controlled by pressing __CONTROL__ll-toggle-moon-view__.
-ll-luna-automation=Luna automation
+ll-luna-automation=Specialized machinery for production on [planet=luna].
 ll-moon-rock-processing=Process moon rock into silicon and oxygen.
 ll-heat-shielding=Protect rockets re-entering Nauvis' atmosphere.
 ll-ice-extraction=Ice can be melted into water for steam-powered rockets and nuclear power.


### PR DESCRIPTION
It seems the "luna automation" technology has the exact same localised name as localised description.

![image](https://github.com/user-attachments/assets/77728531-24f9-435d-a39b-3718701ebecd)

This PR resolves this duplication.

![image](https://github.com/user-attachments/assets/335b516e-a523-4f63-8a94-dafc606ebe62)
